### PR TITLE
Update integration tests to support Nargo v1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,5 +16,12 @@ jobs:
         with:
           toolchain: 1.0.0-beta.9
 
-      - name: Run nargo test
+      - name: Run unit tests
         run: nargo test
+
+      - name: Run integration tests
+        run: |
+          nargo execute --package depth_8_state_proof
+          nargo execute --package depth_8_storage_proof
+          nargo execute --package one_level
+          nargo execute --package rlp_decode

--- a/lib/src/storage_proof.nr
+++ b/lib/src/storage_proof.nr
@@ -8,7 +8,7 @@ use keccak256::keccak256;
 use crate::rlp;
 
 /// Type alias for storage proofs. Assumes value is left-padded with zeros.
-type StorageProof<let PROOF_LEN: u32> = TrieProof<32, PROOF_LEN, MAX_STORAGE_VALUE_LENGTH>;
+pub type StorageProof<let PROOF_LEN: u32> = TrieProof<32, PROOF_LEN, MAX_STORAGE_VALUE_LENGTH>;
 
 impl<let PROOF_LEN: u32, let MAX_VALUE_LEN: u32> TrieProof<32, PROOF_LEN, MAX_VALUE_LEN>
 {

--- a/tests/depth_8_state_proof/src/main.nr
+++ b/tests/depth_8_state_proof/src/main.nr
@@ -1,7 +1,6 @@
 use dep::trie::{trie_proof::TrieProof, const::MAX_ACCOUNT_STATE_LENGTH};
-use dep::std::hash::keccak256;
 
-global DEPTH8_MAX: Field = 4256;
+global DEPTH8_MAX: u32 = 4256;
 
 fn main(
     state_root: pub [u8; 32],

--- a/tests/depth_8_storage_proof/src/main.nr
+++ b/tests/depth_8_storage_proof/src/main.nr
@@ -1,5 +1,5 @@
 use dep::trie::storage_proof::StorageProof;
-global DEPTH8_MAX: Field = 4256;
+global DEPTH8_MAX: u32 = 4256;
 
 fn main(storage_root: pub [u8; 32], storage_proof: StorageProof<DEPTH8_MAX>) {
     assert(storage_proof.verify_storage_root(storage_root));

--- a/tests/rlp_decode/src/main.nr
+++ b/tests/rlp_decode/src/main.nr
@@ -1,7 +1,7 @@
 use dep::trie::const::MAX_NUM_FIELDS;
-use dep::trie::rlp;
+use dep::trie::rlp::{RLP_List, decode1_small_lis};
 
 fn main(input: [u8; 532]) {
-    let rlp_list: rlp::RLP_List<MAX_NUM_FIELDS> = rlp::decode1_small_lis(input);
+    let rlp_list: RLP_List<MAX_NUM_FIELDS> = decode1_small_lis(input);
     assert(rlp_list.num_fields == 17);
 }


### PR DESCRIPTION
This PR updates the integration tests to support Nargo v1. They're now also run in our CI / CD environment.